### PR TITLE
Resolve CVEs and set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Run rubocop
+        run: bundle exec rubocop
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,16 @@ PATH
   remote: .
   specs:
     omniauth-infinum_azure (1.0.0)
+      base64
+      bigdecimal
       omniauth-oauth2
 
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.0)
@@ -15,7 +20,10 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     hashie (5.0.0)
+    json (2.15.2)
     jwt (2.7.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     method_source (1.0.0)
     multi_xml (0.6.0)
     oauth2 (2.0.9)
@@ -32,16 +40,24 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
+    parallel (1.27.0)
+    parser (3.3.10.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.6.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    rack (3.0.4.2)
+    racc (1.8.1)
+    rack (3.2.3)
     rack-protection (3.0.5)
       rack
+    rainbow (3.1.1)
     rake (13.0.6)
+    regexp_parser (2.11.3)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -55,15 +71,34 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
+    rubocop (1.81.6)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.47.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
     version_gem (1.1.1)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  ruby
 
 DEPENDENCIES
   bundler (~> 2.1)
@@ -72,6 +107,7 @@ DEPENDENCIES
   pry-byebug
   rake (~> 13.0)
   rspec (~> 3.0)
+  rubocop
 
 BUNDLED WITH
    2.4.6

--- a/omniauth-infinum_azure.gemspec
+++ b/omniauth-infinum_azure.gemspec
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/infinum_azure/version'
 
-Gem::Specification.new do |spec|
+Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.name = 'omniauth-infinum_azure'
   spec.version = Omniauth::InfinumAzure::VERSION
   spec.authors = ['Marko Ćilimković']
@@ -29,10 +31,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop'
 
+  spec.add_dependency 'base64'
+  spec.add_dependency 'bigdecimal'
   spec.add_dependency 'omniauth-oauth2'
 end


### PR DESCRIPTION
Resolves Rack CVEs by updating to the latest version.
Sets up CI on GH Actions (RuboCop and RSpec).
Adds support for Ruby 3.4 and up by adding `bigdecimal` and `base64` gems as dependencies.